### PR TITLE
Log "external mod directory not found" as info

### DIFF
--- a/cardshifter-core/src/main/java/com/cardshifter/core/game/ModCollection.java
+++ b/cardshifter-core/src/main/java/com/cardshifter/core/game/ModCollection.java
@@ -59,7 +59,7 @@ public class ModCollection {
 	 */
 	public ModCollection loadExternal(Path directory) {
         if (!Files.isDirectory(directory)) {
-            logger.warn(directory.toAbsolutePath() + " not found. External mod directory not loaded");
+            logger.info(directory.toAbsolutePath() + " not found. External mod directory not loaded");
             return this;
         }
         logger.info("Loading mods in " + directory.toAbsolutePath());


### PR DESCRIPTION
I saw this log message and had to check with the chat before being sure that the message didn't mean I had set up my build wrong.

From the [log4j Level docs](http://logging.apache.org/log4j/2.x/log4j-api/apidocs/index.html):

    WARN: An event that might possible [sic] lead to an error.
    INFO: An event for informational purposes.

As I understand it, the message changed in this commit is not indicative of an error, or something that might possibly lead to one.