### PR TITLE
Add starter server.properties for development

### DIFF
--- a/server.properties
+++ b/server.properties
@@ -4,6 +4,6 @@
 # Automatically use standard mods
 mods = extra-resources/mods
 
-# Disable warnings if no security manager is present
-# This should ONLY ever be enabled when running trusted mods!
-missing-security = IGNORE
+# Uncomment to disable warning prompt if no security manager is present
+# This prompt should ONLY ever be ignored when running trusted mods!
+# missing-security = IGNORE

--- a/server.properties
+++ b/server.properties
@@ -1,0 +1,9 @@
+# This file provides starter settings for running the server from an IDE or similar under development
+# For another example of a server.properties see extra-resources/server.properties.example
+
+# Automatically use standard mods
+mods = extra-resources/mods
+
+# Disable warnings if no security manager is present
+# This should ONLY ever be enabled when running trusted mods!
+missing-security = IGNORE


### PR DESCRIPTION
Make running a server from sources inside an IDE or from `gradle build` a zero config business. It is now as simple as cloning the git repo to get everything needed to run a local test server.

Before this commit, anyone who wanted to quickly get into the project and write some code, test something straight from Git or set up a development environment on a new machine first had to figure out how to get the server to find the default mods. Before solving that issue, it's
impossible to start a game.

The properties file also includes a commented out line that disables the warning prompt if no security manager is available. This can be convenient under development if the developer knows that no 3rd party mods are present on the machine. Ignoring the warning should be opt-in rather than opt-out, which is why the line is commented out by default.