### PR TITLE
Remove server.properties in root (revert #340)

### DIFF
--- a/server.properties
+++ b/server.properties
@@ -1,9 +1,0 @@
-# This file provides starter settings for running the server from an IDE or similar under development
-# For another example of a server.properties see extra-resources/server.properties.example
-
-# Automatically use standard mods
-mods = extra-resources/mods
-
-# Uncomment to disable warning prompt if no security manager is present
-# This prompt should ONLY ever be ignored when running trusted mods!
-# missing-security = IGNORE


### PR DESCRIPTION
Since the working directory already should be set to `extra-resources/` in the client, setting it in the server should not be an issue. If the working directory of the server is `extra-resources/` then the file
removed in this commit is redundant.

Setting the working directory is a more elegant solution to how to set up the included mods for the server than including a standard config file.

How to set up the working directory in IDEA is documented in [2) Running the application](https://github.com/Cardshifter/Cardshifter/wiki/2--Running-the-application).

This commit reverts #340 