### PR TITLE
Parallelize build and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ jdk:
 sudo: false
 
 before_script:
-    - export GRADLE_OPTS='-Dorg.gradle.parallel=false'
+    # Gradle daemon won't add any benefit since Travis builds are always from scratch
+    - export GRADLE_OPTS='-Dorg.gradle.daemon=false'
     - chmod +x gradlew
 
 script: "./gradlew distAndTest --info"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ jdk:
 # Use container build
 sudo: false
 
+# Shell nop (install handled by gradle dependency management, no need to first assemble and then test)
+install: ":"
+
 before_script:
     # Gradle daemon won't add any benefit since Travis builds are always from scratch
     - export GRADLE_OPTS='-Dorg.gradle.daemon=false'

--- a/build.gradle
+++ b/build.gradle
@@ -78,9 +78,6 @@ subprojects {
                 exceptionFormat "short"
             }
         }
-        tasks.withType(Test) {
-            maxParallelForks = Runtime.runtime.availableProcessors()
-        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ subprojects {
                 exceptionFormat "short"
             }
         }
+        tasks.withType(Test) {
+            maxParallelForks = Runtime.runtime.availableProcessors()
+        }
     }
 }
 

--- a/cardshifter-server/src/test/java/com/cardshifter/server/main/ServerConnectionTest.java
+++ b/cardshifter-server/src/test/java/com/cardshifter/server/main/ServerConnectionTest.java
@@ -157,7 +157,7 @@ public class ServerConnectionTest {
 		assertFalse(welcomeMessage.isOK());
 	}
 	
-	@Test(timeout = 10000)
+	@Test(timeout = 50000)
 	public void testStartGame() throws InterruptedException, IOException {
 		client1.send(new StartGameRequest(2, getTestMod()));
 		NewGameMessage gameMessage = client1.await(NewGameMessage.class);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Sun, 21 Jun 2015 20:30:02 +0200
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx512m
 org.gradle.configureondemand=true
+org.gradle.parallel=true
 version=0.6.1-SNAPSHOT


### PR DESCRIPTION
These changes enable project level and test level parallelization to the build and test process. I'd like to see benchmarks of these changes from at least one other person. Below is the timing on my MacBook.

```bash
# This commit
$ git checkout ff745ba7cf1beb949b05e63c9b4c5dc176e839c9
$ ./gradlew clean test
...
Total time: 1 mins 35.234 secs

# Previous commit
$ git checkout a7e99be92eba803c15ad5b809091557ef4d03cde
$ ./gradlew clean test
...
Total time: 1 mins 17.313 secs
```

The times vary a bit each time, but the old one is consistently faster. I'd like to see if this is just my machine acting up or if you see a similar pattern.